### PR TITLE
Alternative get_objects_for_events()

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -244,7 +244,6 @@ class EventRelationManager(models.Manager):
     
     def get_objects_for_event(self, event, model, distinction=None):
         '''
-            My own version of get_objects_for_event() method.
             Returns a queryset full of instances of model, if it has an EventRelation
             with event, and distinction
             >>> event = Event.objects.get(pk='1')

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -240,6 +240,26 @@ class EventRelationManager(models.Manager):
     #         eventrelation__content_type = ct,
     #         eventrelation__event = event
     #     )
+    
+    
+    def get_objects_for_avent(self, event, model, distinction=None):
+        '''
+            Alternative version for original get_objects_for_event() method.
+            Returns a queryset full of instances of model, if it has an EventRelation
+            with event, and distinction
+            >>> event = Event.objects.get(pk='1')
+            >>> EventRelation.objects.get_objects_for_avent(event, Block, distinction='1')
+            [<EventRelation: teste(1)-Principal>]
+            >>> EventRelation.objects.get_objects_for_avent(event, Block)
+            [<EventRelation: teste(1)-Principal>, <EventRelation: teste(2)-Secundario>]
+        '''
+        if distinction:
+            dist_q = Q(distinction = distinction)
+        else:
+            dist_q = Q()
+        ct = ContentType.objects.get_for_model(model)
+        return event.eventrelation_set.filter(dist_q, content_type = ct)
+    
 
     def get_events_for_object(self, content_object, distinction=None, inherit=True):
         '''

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -242,9 +242,9 @@ class EventRelationManager(models.Manager):
     #     )
     
     
-    def get_objects_for_avent(self, event, model, distinction=None):
+    def get_objects_for_event(self, event, model, distinction=None):
         '''
-            Alternative version for original get_objects_for_event() method.
+            My own version of get_objects_for_event() method.
             Returns a queryset full of instances of model, if it has an EventRelation
             with event, and distinction
             >>> event = Event.objects.get(pk='1')
@@ -258,8 +258,9 @@ class EventRelationManager(models.Manager):
         else:
             dist_q = Q()
         ct = ContentType.objects.get_for_model(model)
-        return event.eventrelation_set.filter(dist_q, content_type = ct)
-    
+        el = event.eventrelation_set.filter(dist_q, content_type = ct)
+        ol = [e.content_object for e in el]
+        return ol
 
     def get_events_for_object(self, content_object, distinction=None, inherit=True):
         '''


### PR DESCRIPTION
I just added a alternative get_objects_for_events() method to substitute which does not work
